### PR TITLE
Implement an optional kafaka consumer to help read message from queue

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -13,6 +13,8 @@ import (
 	"time"
 
 	"github.com/erain9/matchingo/pkg/api/proto"
+	"github.com/erain9/matchingo/pkg/db/queue"
+	"github.com/erain9/matchingo/pkg/messaging"
 	"github.com/erain9/matchingo/pkg/server"
 	"github.com/rs/zerolog"
 	"google.golang.org/grpc"
@@ -56,6 +58,40 @@ func main() {
 	}
 
 	logger.Info().Str("name", "test").Msg("Created test order book")
+
+	// Initialize Kafka consumer (optional)
+	// The consumer is for developer purpose which helps pretty print the message
+	// in the queue.
+	var kafkaConsumer *queue.QueueMessageConsumer
+	kafkaConsumer, err = queue.NewQueueMessageConsumer()
+	if err != nil {
+		logger.Warn().Err(err).Msg("Failed to create Kafka consumer - continuing without Kafka support")
+	} else {
+		defer kafkaConsumer.Close()
+
+		// Start Kafka consumer in a goroutine
+		go func() {
+			logger.Info().Msg("Starting Kafka consumer")
+			err := kafkaConsumer.ConsumeDoneMessages(func(msg *messaging.DoneMessage) error {
+				logger.Info().
+					Str("order_id", msg.OrderID).
+					Str("executed_qty", msg.ExecutedQty).
+					Str("remaining_qty", msg.RemainingQty).
+					Strs("canceled", msg.Canceled).
+					Strs("activated", msg.Activated).
+					Bool("stored", msg.Stored).
+					Str("quantity", msg.Quantity).
+					Str("processed", msg.Processed).
+					Str("left", msg.Left).
+					Interface("trades", msg.Trades).
+					Msg("Received done message")
+				return nil
+			})
+			if err != nil {
+				logger.Error().Err(err).Msg("Kafka consumer error")
+			}
+		}()
+	}
 
 	// Start gRPC server
 	grpcAddr := fmt.Sprintf(":%d", *grpcPort)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/erain9/matchingo
 
-go 1.22.0
+go 1.23
 
 toolchain go1.24.2
 
@@ -10,6 +10,7 @@ require (
 	github.com/nikolaydubina/fpdecimal v0.16.0
 	github.com/redis/go-redis/v9 v9.7.3
 	github.com/rs/zerolog v1.34.0
+	github.com/stretchr/testify v1.10.0
 	google.golang.org/grpc v1.71.1
 	google.golang.org/protobuf v1.36.6
 )
@@ -31,13 +32,17 @@ require (
 	github.com/jcmturner/gokrb5/v8 v8.4.4 // indirect
 	github.com/jcmturner/rpc/v2 v2.0.3 // indirect
 	github.com/klauspost/compress v1.17.11 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/pierrec/lz4/v4 v4.1.22 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
+	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	golang.org/x/crypto v0.33.0 // indirect
 	golang.org/x/net v0.35.0 // indirect
 	golang.org/x/sys v0.30.0 // indirect
 	golang.org/x/text v0.22.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250115164207-1a7da9e5054f // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,7 @@ github.com/bsm/gomega v1.27.10/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -58,6 +59,10 @@ github.com/jcmturner/rpc/v2 v2.0.3 h1:7FXXj8Ti1IaVFpSAziCZWNzbNuZmnvw/i6CqLNdWfZ
 github.com/jcmturner/rpc/v2 v2.0.3/go.mod h1:VUJYCIDm3PVOEHw8sgt091/20OJjskO/YJki3ELg/Hc=
 github.com/klauspost/compress v1.17.11 h1:In6xLpyWOi1+C7tXUUWv2ot1QvBjxevKAaI6IXrJmUc=
 github.com/klauspost/compress v1.17.11/go.mod h1:pMDklpSncoRMuLFrf1W9Ss9KT+0rH90U12bZKk7uwG0=
+github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
@@ -75,6 +80,8 @@ github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5X
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/redis/go-redis/v9 v9.7.3 h1:YpPyAayJV+XErNsatSElgRZZVCwXX9QzkKYNvO7x0wM=
 github.com/redis/go-redis/v9 v9.7.3/go.mod h1:bGUrSggJ9X9GUmZpZNEOQKaANxSGgOEBRltRTZHSvrA=
+github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
+github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/rs/xid v1.6.0/go.mod h1:7XoLgs4eV+QndskICGsho+ADou8ySMSjJKDIan90Nz0=
 github.com/rs/zerolog v1.34.0 h1:k43nTLIwcTVQAncfCw4KZ2VY6ukYoZaBPNOE8txlOeY=
 github.com/rs/zerolog v1.34.0/go.mod h1:bJsvje4Z08ROH4Nhs5iH600c3IkWhwp44iRc54W6wYQ=
@@ -149,6 +156,8 @@ google.golang.org/grpc v1.71.1/go.mod h1:H0GRtasmQOh9LkFoCPDu3ZrwUtD1YGE+b2vYBYd
 google.golang.org/protobuf v1.36.6 h1:z1NpPI8ku2WgiWnf+t9wTPsn6eP1L7ksHUlkfLvd9xY=
 google.golang.org/protobuf v1.36.6/go.mod h1:jduwjTPXsFjZGTmRluh+L6NjiWu7pchiJ2/5YcXBHnY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/pkg/api/proto/orderbook.proto
+++ b/pkg/api/proto/orderbook.proto
@@ -186,17 +186,24 @@ message PriceLevel {
 
 // Represents a trade that has occurred
 message Trade {
-  string price = 1;
-  string quantity = 2;
+  string order_id = 1;
+  string role = 2;
+  string price = 3;
+  string quantity = 4;
+  bool is_quote = 5;
 }
 
 // DoneMessage represents the message structure for the Done object
 // to be sent to the message queue
-// TODO: This is just a simplied version of message for demo, subject
-// to revisit.
 message DoneMessage {
   string order_id = 1;
   string executed_quantity = 2;
   string remaining_quantity = 3;
   repeated Trade trades = 4;
+  repeated string canceled = 5;
+  repeated string activated = 6;
+  bool stored = 7;
+  string quantity = 8;
+  string processed = 9;
+  string left = 10;
 } 

--- a/pkg/core/orderbook.go
+++ b/pkg/core/orderbook.go
@@ -337,6 +337,12 @@ func (ob *OrderBook) processLimitOrder(limitOrder *Order) (done *Done, err error
 		ExecutedQty:  done.Processed.String(),
 		RemainingQty: done.Left.String(),
 		Trades:       convertTrades(done.tradesToSlice()),
+		Canceled:     done.Canceled,
+		Activated:    done.Activated,
+		Stored:       done.Stored,
+		Quantity:     done.Quantity.String(),
+		Processed:    done.Processed.String(),
+		Left:         done.Left.String(),
 	}
 
 	// Send the DoneMessage to Kafka. This won't block the call
@@ -469,9 +475,16 @@ func (ob *OrderBook) GetAsks() interface{} {
 func convertTrades(trades []TradeOrder) []messaging.Trade {
 	converted := make([]messaging.Trade, len(trades))
 	for i, trade := range trades {
+		role := "MAKER"
+		if trade.Role == TAKER {
+			role = "TAKER"
+		}
 		converted[i] = messaging.Trade{
+			OrderID:  trade.OrderID,
+			Role:     role,
 			Price:    trade.Price.String(),
 			Quantity: trade.Quantity.String(),
+			IsQuote:  trade.IsQuote,
 		}
 	}
 	return converted

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -112,6 +112,9 @@ func (d *Done) setLeftQuantity(quantity *fpdecimal.Decimal) {
 
 // Helper function to create trade orders
 func newTradeOrder(order *Order, quantity, price fpdecimal.Decimal) *TradeOrder {
+	if order == nil {
+		return nil
+	}
 	return &TradeOrder{
 		OrderID:  order.ID(),
 		Role:     order.Role(),

--- a/pkg/db/queue/mock_producer.go
+++ b/pkg/db/queue/mock_producer.go
@@ -1,0 +1,52 @@
+package queue
+
+import (
+	"github.com/IBM/sarama"
+)
+
+// mockProducer implements just enough of sarama.SyncProducer for our tests
+type mockProducer struct {
+	sentMessages []*sarama.ProducerMessage
+}
+
+func (m *mockProducer) SendMessage(msg *sarama.ProducerMessage) (partition int32, offset int64, err error) {
+	m.sentMessages = append(m.sentMessages, msg)
+	return 0, 0, nil
+}
+
+func (m *mockProducer) SendMessages(msgs []*sarama.ProducerMessage) error {
+	m.sentMessages = append(m.sentMessages, msgs...)
+	return nil
+}
+
+func (m *mockProducer) Close() error {
+	return nil
+}
+
+func (m *mockProducer) TxnStatus() sarama.ProducerTxnStatusFlag {
+	return 0
+}
+
+func (m *mockProducer) BeginTxn() error {
+	return nil
+}
+
+func (m *mockProducer) CommitTxn() error {
+	return nil
+}
+
+func (m *mockProducer) AbortTxn() error {
+	return nil
+}
+
+func (m *mockProducer) AddMessageToTxn(msg *sarama.ConsumerMessage, groupID string, metadata *string) error {
+	return nil
+}
+
+func (m *mockProducer) AddOffsetsToTxn(offsets map[string][]*sarama.PartitionOffsetMetadata, groupID string) error {
+	return nil
+}
+
+func (m *mockProducer) IsTransactional() bool {
+	return false
+}

--- a/pkg/db/queue/queue_test.go
+++ b/pkg/db/queue/queue_test.go
@@ -1,0 +1,256 @@
+package queue
+
+import (
+	"testing"
+	"time"
+
+	"github.com/IBM/sarama"
+	orderbookpb "github.com/erain9/matchingo/pkg/api/proto"
+	"github.com/erain9/matchingo/pkg/messaging"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+type mockConsumer struct {
+	messages chan *sarama.ConsumerMessage
+	errors   chan *sarama.ConsumerError
+}
+
+func (m *mockConsumer) ConsumePartition(topic string, partition int32, offset int64) (sarama.PartitionConsumer, error) {
+	return &mockPartitionConsumer{
+		messages: m.messages,
+		errors:   m.errors,
+	}, nil
+}
+
+func (m *mockConsumer) Topics() ([]string, error) {
+	return []string{}, nil
+}
+
+func (m *mockConsumer) Partitions(topic string) ([]int32, error) {
+	return []int32{}, nil
+}
+
+func (m *mockConsumer) HighWaterMarks() map[string]map[int32]int64 {
+	return nil
+}
+
+func (m *mockConsumer) Close() error {
+	close(m.messages)
+	close(m.errors)
+	return nil
+}
+
+func (m *mockConsumer) Pause(topicPartitions map[string][]int32) {}
+
+func (m *mockConsumer) Resume(topicPartitions map[string][]int32) {}
+
+func (m *mockConsumer) PauseAll() {}
+
+func (m *mockConsumer) ResumeAll() {}
+
+type mockPartitionConsumer struct {
+	messages chan *sarama.ConsumerMessage
+	errors   chan *sarama.ConsumerError
+}
+
+func (m *mockPartitionConsumer) AsyncClose() {}
+
+func (m *mockPartitionConsumer) Close() error {
+	return nil
+}
+
+func (m *mockPartitionConsumer) Messages() <-chan *sarama.ConsumerMessage {
+	return m.messages
+}
+
+func (m *mockPartitionConsumer) Errors() <-chan *sarama.ConsumerError {
+	return m.errors
+}
+
+func (m *mockPartitionConsumer) HighWaterMarkOffset() int64 {
+	return 0
+}
+
+func (m *mockPartitionConsumer) IsPaused() bool {
+	return false
+}
+
+func (m *mockPartitionConsumer) Pause() {}
+
+func (m *mockPartitionConsumer) Resume() {}
+
+func TestQueueMessageSender_SendDoneMessage(t *testing.T) {
+	// Create a test message
+	doneMessage := &messaging.DoneMessage{
+		OrderID:      "test-order-1",
+		ExecutedQty:  "100.5",
+		RemainingQty: "50.0",
+		Trades: []messaging.Trade{
+			{
+				OrderID:  "trade-1",
+				Role:     "MAKER",
+				Price:    "100.0",
+				Quantity: "50.0",
+				IsQuote:  true,
+			},
+		},
+		Canceled:  []string{"cancel-1", "cancel-2"},
+		Activated: []string{"activate-1"},
+		Stored:    true,
+		Quantity:  "150.5",
+		Processed: "100.5",
+		Left:      "50.0",
+	}
+
+	// Create sender with mock producer
+	sender := &QueueMessageSender{}
+
+	// Override the producer creation with our mock
+	oldNewSyncProducer := newSyncProducer
+	defer func() { newSyncProducer = oldNewSyncProducer }()
+
+	mockProd := &mockProducer{}
+	newSyncProducer = func(addrs []string, config *sarama.Config) (sarama.SyncProducer, error) {
+		return mockProd, nil
+	}
+
+	// Test sending message
+	err := sender.SendDoneMessage(doneMessage)
+	require.NoError(t, err)
+
+	// Verify the message was sent
+	require.Len(t, mockProd.sentMessages, 1)
+	msg := mockProd.sentMessages[0]
+
+	// Verify the message content
+	require.Equal(t, topic, msg.Topic)
+
+	// Unmarshal the message value to verify its content
+	var protoMsg orderbookpb.DoneMessage
+	err = proto.Unmarshal(msg.Value.(sarama.ByteEncoder), &protoMsg)
+	require.NoError(t, err)
+
+	require.Equal(t, doneMessage.OrderID, protoMsg.OrderId)
+	require.Equal(t, doneMessage.ExecutedQty, protoMsg.ExecutedQuantity)
+	require.Equal(t, doneMessage.RemainingQty, protoMsg.RemainingQuantity)
+	require.Equal(t, doneMessage.Quantity, protoMsg.Quantity)
+	require.Equal(t, doneMessage.Processed, protoMsg.Processed)
+	require.Equal(t, doneMessage.Left, protoMsg.Left)
+	require.Equal(t, doneMessage.Stored, protoMsg.Stored)
+	require.Equal(t, len(doneMessage.Trades), len(protoMsg.Trades))
+	require.Equal(t, len(doneMessage.Canceled), len(protoMsg.Canceled))
+	require.Equal(t, len(doneMessage.Activated), len(protoMsg.Activated))
+}
+
+func TestQueueMessageConsumer_ConsumeDoneMessages(t *testing.T) {
+	// Create a test message
+	expectedMessage := &messaging.DoneMessage{
+		OrderID:      "test-order-1",
+		ExecutedQty:  "100.5",
+		RemainingQty: "50.0",
+		Trades: []messaging.Trade{
+			{
+				OrderID:  "trade-1",
+				Role:     "MAKER",
+				Price:    "100.0",
+				Quantity: "50.0",
+				IsQuote:  true,
+			},
+		},
+		Canceled:  []string{"cancel-1", "cancel-2"},
+		Activated: []string{"activate-1"},
+		Stored:    true,
+		Quantity:  "150.5",
+		Processed: "100.5",
+		Left:      "50.0",
+	}
+
+	// Create a mock consumer
+	mockConsumer := &mockConsumer{
+		messages: make(chan *sarama.ConsumerMessage, 1),
+		errors:   make(chan *sarama.ConsumerError, 1),
+	}
+
+	// Create consumer
+	consumer := &QueueMessageConsumer{
+		consumer: mockConsumer,
+		done:     make(chan struct{}),
+	}
+
+	// Create a channel to receive the processed message
+	receivedMessage := make(chan *messaging.DoneMessage, 1)
+
+	// Start consuming in a goroutine
+	go func() {
+		err := consumer.ConsumeDoneMessages(func(msg *messaging.DoneMessage) error {
+			receivedMessage <- msg
+			return nil
+		})
+		require.NoError(t, err)
+	}()
+
+	// Send a test message
+	mockConsumer.messages <- &sarama.ConsumerMessage{
+		Value: mustMarshalProto(t, expectedMessage),
+	}
+
+	// Wait for message to be processed
+	select {
+	case msg := <-receivedMessage:
+		assert.Equal(t, expectedMessage.OrderID, msg.OrderID)
+		assert.Equal(t, expectedMessage.ExecutedQty, msg.ExecutedQty)
+		assert.Equal(t, expectedMessage.RemainingQty, msg.RemainingQty)
+		assert.Equal(t, expectedMessage.Quantity, msg.Quantity)
+		assert.Equal(t, expectedMessage.Processed, msg.Processed)
+		assert.Equal(t, expectedMessage.Left, msg.Left)
+		assert.Equal(t, expectedMessage.Stored, msg.Stored)
+		assert.Equal(t, len(expectedMessage.Trades), len(msg.Trades))
+		assert.Equal(t, len(expectedMessage.Canceled), len(msg.Canceled))
+		assert.Equal(t, len(expectedMessage.Activated), len(msg.Activated))
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for message")
+	}
+
+	// Close the consumer
+	err := consumer.Close()
+	require.NoError(t, err)
+}
+
+func mustMarshalProto(t *testing.T, msg *messaging.DoneMessage) []byte {
+	// Convert to proto message
+	protoMsg := &orderbookpb.DoneMessage{
+		OrderId:           msg.OrderID,
+		ExecutedQuantity:  msg.ExecutedQty,
+		RemainingQuantity: msg.RemainingQty,
+		Canceled:          msg.Canceled,
+		Activated:         msg.Activated,
+		Stored:            msg.Stored,
+		Quantity:          msg.Quantity,
+		Processed:         msg.Processed,
+		Left:              msg.Left,
+	}
+
+	// Convert trades to proto format
+	if len(msg.Trades) > 0 {
+		protoMsg.Trades = make([]*orderbookpb.Trade, 0, len(msg.Trades))
+		for _, trade := range msg.Trades {
+			protoMsg.Trades = append(protoMsg.Trades, &orderbookpb.Trade{
+				OrderId:  trade.OrderID,
+				Role:     trade.Role,
+				Price:    trade.Price,
+				Quantity: trade.Quantity,
+				IsQuote:  trade.IsQuote,
+			})
+		}
+	}
+
+	// Serialize to protobuf
+	messageBytes, err := proto.Marshal(protoMsg)
+	if err != nil {
+		t.Fatalf("failed to marshal done message: %v", err)
+	}
+
+	return messageBytes
+}

--- a/pkg/messaging/messaging.go
+++ b/pkg/messaging/messaging.go
@@ -14,10 +14,19 @@ type DoneMessage struct {
 	ExecutedQty  string
 	RemainingQty string
 	Trades       []Trade
+	Canceled     []string
+	Activated    []string
+	Stored       bool
+	Quantity     string
+	Processed    string
+	Left         string
 }
 
 // Trade represents a single trade execution
 type Trade struct {
+	OrderID  string
+	Role     string
 	Price    string
 	Quantity string
+	IsQuote  bool
 }


### PR DESCRIPTION
Sample message received after a trade

```
2025-04-09T22:31:36-04:00 INF Received done message activated=[] canceled=[] executed_qty=1.000 left=0 order_id=order2 processed=1.000 quantity=1.000 remaining_qty=0 stored=false trades=[{"IsQuote":false,"OrderID":"order2","Price":"50000.000","Quantity":"1.000","Role":"TAKER"},{"IsQuote":false,"OrderID":"order1","Price":"50000.000","Quantity":"1.000","Role":"MAKER"}]
```