### PR TITLE
feat: Add cumulative metric for matching orders by sides

### DIFF
--- a/pkg/otel/order_metrics.go
+++ b/pkg/otel/order_metrics.go
@@ -1,0 +1,55 @@
+package otel
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+var (
+	// orderBookMetrics holds the singleton instance
+	orderBookMetrics *OrderBookMetrics
+	// meter is the global meter for order book metrics
+	meter = otel.GetMeterProvider().Meter(instrumentationName)
+)
+
+// OrderBookMetrics holds metrics for order book operations
+type OrderBookMetrics struct {
+	// Tracks the total number of matched orders by type (market, limit)
+	matchedOrdersTotal metric.Int64Counter
+}
+
+// GetOrderBookMetrics returns the OrderBookMetrics singleton
+func GetOrderBookMetrics() *OrderBookMetrics {
+	if orderBookMetrics == nil {
+		// Initialize metrics
+		matchedOrdersTotal, err := meter.Int64Counter(
+			"orderbook.matched_orders.total",
+			metric.WithDescription("Total number of orders matched"),
+			metric.WithUnit("{order}"),
+		)
+		if err != nil {
+			return &OrderBookMetrics{}
+		}
+
+		orderBookMetrics = &OrderBookMetrics{
+			matchedOrdersTotal: matchedOrdersTotal,
+		}
+	}
+
+	return orderBookMetrics
+}
+
+// RecordMatchedOrders increments the matched orders counter
+func (m *OrderBookMetrics) RecordMatchedOrders(ctx context.Context, orderType string, count int64) {
+	if m.matchedOrdersTotal == nil {
+		return
+	}
+
+	attrs := []attribute.KeyValue{
+		attribute.String("order.type", orderType),
+	}
+	m.matchedOrdersTotal.Add(ctx, count, metric.WithAttributes(attrs...))
+}


### PR DESCRIPTION
Tested by checking load test that half of the orders created were matched:
<img width="824" alt="e43284241983212037b35aeae086d4c" src="https://github.com/user-attachments/assets/4da7985b-5b8e-496f-ac90-f9276933ca9e" />
