### PR TITLE
feat: lower the trace sampling rate to 0.01%

### DIFF
--- a/pkg/otel/otel.go
+++ b/pkg/otel/otel.go
@@ -186,7 +186,7 @@ func initTracerProvider(cfg Config, resource *sdkresource.Resource) (*sdktrace.T
 		sdktrace.WithBatcher(exporter),
 		sdktrace.WithResource(resource),
 		sdktrace.WithSampler(sdktrace.ParentBased(
-			sdktrace.TraceIDRatioBased(0.4), // Sample 10% of traces
+			sdktrace.TraceIDRatioBased(0.0001), // Sample 0.01% of traces
 		)),
 	)
 


### PR DESCRIPTION
- trace is expensive with datadog, so need to make it much lower for our loadtest use